### PR TITLE
Rename Domain Colors to Memory Domains with multi-select

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -395,13 +395,12 @@
     <h3>
       <span id="selection-panel-title">Selected Nodes</span>
       <span class="selection-count" id="selection-count">0</span>
-      <span class="copy-icon" id="selection-copy" title="Copy to clipboard">📋</span>
-      <span class="close-icon" id="selection-close" title="Close panel">✖</span>
     </h3>
     <div id="selection-list"></div>
     <div id="selection-actions">
-      <button id="clear-selection-btn">Clear Selection</button>
-      <button id="link-selected-btn">Link All Selected</button>
+      <button id="clear-selection-btn">Clear</button>
+      <button id="link-selected-btn">Link</button>
+      <button id="change-domain-btn">Domain</button>
     </div>
   </div>
   

--- a/public/index.html
+++ b/public/index.html
@@ -376,7 +376,6 @@
   <div id="info-panel">
     <h3>
       <span id="node-id">Node Details</span>
-      <span class="copy-icon" id="copy-to-clipboard" title="Copy to clipboard">📋</span>
     </h3>
     <div id="node-tags"></div>
     <div id="node-content" class="content"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -98,6 +98,15 @@
       background-color: rgba(255, 100, 100, 0.2);
     }
     
+    /* Delete button styles */
+    .delete-button {
+      color: #ff6b6b;
+    }
+    
+    .delete-button:hover {
+      background-color: rgba(255, 70, 70, 0.2);
+    }
+    
     /* Selection count badge */
     .selection-count {
       background-color: rgba(100, 180, 100, 0.5);

--- a/public/js/app.modular.v2.js
+++ b/public/js/app.modular.v2.js
@@ -38,11 +38,11 @@ document.addEventListener('DOMContentLoaded', () => {
   
   // Load initial data
   graph.loadData().then(() => {
-    // Initialize domain color legend after data is loaded
-    console.log('Data loaded, updating domain color legend');
+    // Initialize memory domains panel after data is loaded
+    console.log('Data loaded, updating memory domains panel');
     // Ensure all domains are collected from the graph data
     domainManagement.collectAllDomains();
-    domainManagement.updateDomainColorLegend();
+    domainManagement.updateMemoryDomainsPanel();
     
     // Initialize domain legend as draggable if it was created
     const domainLegend = document.getElementById('domain-legend');
@@ -53,8 +53,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }).catch(error => {
     console.error('Error loading data:', error);
-    // Initialize domain color legend even if data loading fails
-    domainManagement.updateDomainColorLegend();
+    // Initialize memory domains panel even if data loading fails
+    domainManagement.updateMemoryDomainsPanel();
   });
   
   // Fetch link types

--- a/public/js/modules-v2/core/domainManagement.js
+++ b/public/js/modules-v2/core/domainManagement.js
@@ -104,6 +104,316 @@ export function handleChangeDomain(node, newDomain) {
 }
 
 /**
+ * Get the count of nodes for each domain
+ * @returns {Map} - Map of domain to node count
+ */
+export function getDomainNodeCounts() {
+  const { graphData } = store.getState();
+  const domainCounts = new Map();
+  
+  if (graphData && graphData.nodes) {
+    graphData.nodes.forEach(node => {
+      if (node.domain) {
+        domainCounts.set(node.domain, (domainCounts.get(node.domain) || 0) + 1);
+      }
+    });
+  }
+  
+  return domainCounts;
+}
+
+/**
+ * Show the domain name edit dialog
+ * @param {string} currentDomain - The current domain name
+ * @param {function} onComplete - Callback when edit is complete
+ */
+function showDomainEditDialog(currentDomain, onComplete) {
+  // Create modal dialog
+  const modal = document.createElement('div');
+  modal.style.position = 'fixed';
+  modal.style.top = '50%';
+  modal.style.left = '50%';
+  modal.style.transform = 'translate(-50%, -50%)';
+  modal.style.backgroundColor = 'rgba(30, 30, 40, 0.95)';
+  modal.style.padding = '20px';
+  modal.style.borderRadius = '8px';
+  modal.style.boxShadow = '0 0 20px rgba(0, 0, 0, 0.7)';
+  modal.style.zIndex = '1000';
+  modal.style.minWidth = '300px';
+  modal.style.border = '1px solid rgba(100, 100, 255, 0.3)';
+  
+  // Add title
+  const title = document.createElement('h3');
+  title.textContent = 'Edit Domain Name';
+  title.style.marginTop = '0';
+  title.style.marginBottom = '15px';
+  title.style.color = '#aaccff';
+  title.style.borderBottom = '1px solid #5a5a8a';
+  title.style.paddingBottom = '10px';
+  modal.appendChild(title);
+  
+  // Add input
+  const inputContainer = document.createElement('div');
+  inputContainer.style.marginBottom = '20px';
+  
+  const label = document.createElement('label');
+  label.textContent = 'Domain Name:';
+  label.style.display = 'block';
+  label.style.marginBottom = '5px';
+  inputContainer.appendChild(label);
+  
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.value = currentDomain;
+  input.style.width = '100%';
+  input.style.padding = '8px';
+  input.style.backgroundColor = 'rgba(40, 40, 60, 0.7)';
+  input.style.color = '#fff';
+  input.style.border = '1px solid rgba(100, 100, 255, 0.3)';
+  input.style.borderRadius = '4px';
+  input.style.boxSizing = 'border-box';
+  inputContainer.appendChild(input);
+  
+  modal.appendChild(inputContainer);
+  
+  // Add buttons
+  const buttonContainer = document.createElement('div');
+  buttonContainer.style.display = 'flex';
+  buttonContainer.style.justifyContent = 'flex-end';
+  buttonContainer.style.gap = '10px';
+  
+  const cancelButton = document.createElement('button');
+  cancelButton.textContent = 'Cancel';
+  cancelButton.style.padding = '8px 16px';
+  cancelButton.style.backgroundColor = '#525252';
+  cancelButton.style.color = '#fff';
+  cancelButton.style.border = 'none';
+  cancelButton.style.borderRadius = '4px';
+  cancelButton.style.cursor = 'pointer';
+  cancelButton.addEventListener('click', () => {
+    document.body.removeChild(modal);
+  });
+  buttonContainer.appendChild(cancelButton);
+  
+  const saveButton = document.createElement('button');
+  saveButton.textContent = 'Save';
+  saveButton.style.padding = '8px 16px';
+  saveButton.style.backgroundColor = '#2a5298';
+  saveButton.style.color = '#fff';
+  saveButton.style.border = 'none';
+  saveButton.style.borderRadius = '4px';
+  saveButton.style.cursor = 'pointer';
+  saveButton.addEventListener('click', () => {
+    const newDomain = input.value.trim();
+    if (newDomain) {
+      document.body.removeChild(modal);
+      if (onComplete) onComplete(newDomain);
+    }
+  });
+  buttonContainer.appendChild(saveButton);
+  
+  modal.appendChild(buttonContainer);
+  
+  // Add to document
+  document.body.appendChild(modal);
+  
+  // Focus input
+  input.focus();
+  input.select();
+  
+  // Add Enter key handler
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      saveButton.click();
+    }
+  });
+}
+
+/**
+ * Create a new domain
+ */
+export function handleCreateDomain() {
+  showDomainEditDialog('New Domain', (newDomain) => {
+    console.log(`Creating new domain: ${newDomain}`);
+    
+    // Assign a color to the new domain
+    if (window.domainColors && !window.domainColors.has(newDomain)) {
+      const colorIdx = window.colorIndex % window.domainColorPalette.length;
+      window.domainColors.set(newDomain, window.domainColorPalette[colorIdx]);
+      window.colorIndex++;
+    }
+    
+    // Add the domain to the list
+    const allDomains = store.get('allDomains') || [];
+    if (!allDomains.includes(newDomain)) {
+      allDomains.push(newDomain);
+      allDomains.sort();
+      store.set('allDomains', allDomains);
+    }
+    
+    // Update the legend
+    updateDomainColorLegend();
+  });
+}
+
+/**
+ * Rename a domain
+ * @param {string} oldDomain - The domain to rename
+ */
+export function handleRenameDomain(oldDomain) {
+  showDomainEditDialog(oldDomain, (newDomain) => {
+    console.log(`Renaming domain: ${oldDomain} to ${newDomain}`);
+    
+    // Check if the new domain already exists
+    const allDomains = store.get('allDomains') || [];
+    if (allDomains.includes(newDomain) && newDomain !== oldDomain) {
+      alert(`Domain "${newDomain}" already exists. Please choose a different name.`);
+      return;
+    }
+    
+    // Get all nodes with the old domain
+    const { graphData } = store.getState();
+    const nodesToUpdate = graphData.nodes.filter(node => node.domain === oldDomain);
+    
+    if (nodesToUpdate.length === 0) {
+      console.log(`No nodes found with domain ${oldDomain}`);
+      return;
+    }
+    
+    // Show confirmation dialog
+    if (!confirm(`Are you sure you want to rename domain "${oldDomain}" to "${newDomain}"? This will update ${nodesToUpdate.length} nodes.`)) {
+      return;
+    }
+    
+    // Update each node's domain
+    let updatedCount = 0;
+    let errorCount = 0;
+    
+    const updatePromises = nodesToUpdate.map(node => {
+      // Prepare update data
+      const updateData = {
+        nodeId: node.id,
+        domain: newDomain
+      };
+      
+      // Update via API
+      return fetch('/api/nodes/update-domain', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(updateData)
+      })
+      .then(response => response.json())
+      .then(result => {
+        if (result.success) {
+          console.log(`Domain of node ${node.id} updated successfully`);
+          updatedCount++;
+          
+          // Update the node in our graph data
+          const nodeIndex = graphData.nodes.findIndex(n => n.id === node.id);
+          if (nodeIndex !== -1) {
+            graphData.nodes[nodeIndex].domain = newDomain;
+            graphData.nodes[nodeIndex].group = newDomain; // For ForceGraph
+          }
+          
+          return { success: true, node };
+        } else {
+          console.error(`Failed to update domain of node ${node.id}:`, result.error);
+          errorCount++;
+          return { success: false, node, error: result.error };
+        }
+      })
+      .catch(error => {
+        console.error(`Error updating domain of node ${node.id}:`, error);
+        errorCount++;
+        return { success: false, node, error };
+      });
+    });
+    
+    // Process all updates
+    Promise.all(updatePromises)
+      .then(() => {
+        console.log(`Updated domain for ${updatedCount}/${nodesToUpdate.length} nodes, ${errorCount} errors`);
+        
+        // Update the graph
+        const { graph } = store.getState();
+        if (graph) {
+          graph.graphData(graphData);
+        }
+        
+        // Update state
+        store.set('graphData', graphData);
+        
+        // Update domain colors
+        if (window.domainColors) {
+          // Transfer the color from old domain to new domain
+          if (window.domainColors.has(oldDomain)) {
+            const color = window.domainColors.get(oldDomain);
+            window.domainColors.set(newDomain, color);
+            window.domainColors.delete(oldDomain);
+          }
+        }
+        
+        // Update allDomains
+        const domainIndex = allDomains.indexOf(oldDomain);
+        if (domainIndex !== -1) {
+          allDomains.splice(domainIndex, 1);
+          if (!allDomains.includes(newDomain)) {
+            allDomains.push(newDomain);
+            allDomains.sort();
+          }
+          store.set('allDomains', allDomains);
+        }
+        
+        // Update domain legend
+        updateDomainColorLegend();
+        
+        // Show result
+        alert(`Updated domain for ${updatedCount} nodes, ${errorCount} errors`);
+      });
+  });
+}
+
+/**
+ * Delete a domain that has no nodes
+ * @param {string} domain - The domain to delete
+ */
+export function handleDeleteEmptyDomain(domain) {
+  // Check if the domain has any nodes
+  const domainCounts = getDomainNodeCounts();
+  const nodeCount = domainCounts.get(domain) || 0;
+  
+  if (nodeCount > 0) {
+    alert(`Cannot delete domain "${domain}" because it contains ${nodeCount} nodes. Move the nodes to another domain first.`);
+    return;
+  }
+  
+  // Show confirmation dialog
+  if (!confirm(`Are you sure you want to delete the empty domain "${domain}"?`)) {
+    return;
+  }
+  
+  // Remove the domain from the list
+  const allDomains = store.get('allDomains') || [];
+  const domainIndex = allDomains.indexOf(domain);
+  if (domainIndex !== -1) {
+    allDomains.splice(domainIndex, 1);
+    store.set('allDomains', allDomains);
+  }
+  
+  // Remove the domain color
+  if (window.domainColors && window.domainColors.has(domain)) {
+    window.domainColors.delete(domain);
+  }
+  
+  // Update the legend
+  updateDomainColorLegend();
+  
+  console.log(`Deleted empty domain: ${domain}`);
+}
+
+/**
  * Update the domain color legend
  */
 export function updateDomainColorLegend() {
@@ -148,6 +458,9 @@ export function updateDomainColorLegend() {
     }
   });
   
+  // Get node counts for each domain
+  const domainCounts = getDomainNodeCounts();
+  
   // Get or create the legend element
   let legend = document.getElementById('domain-legend');
   
@@ -159,55 +472,14 @@ export function updateDomainColorLegend() {
     legend.style.bottom = '10px';
     legend.style.right = '10px';
     legend.style.backgroundColor = 'rgba(20, 20, 30, 0.85)';
-    legend.style.padding = '10px';
-    legend.style.borderRadius = '5px';
-    legend.style.boxShadow = '0 0 10px rgba(0, 0, 0, 0.5)';
+    legend.style.padding = '20px';
+    legend.style.borderRadius = '8px';
+    legend.style.boxShadow = '0 0 20px rgba(0, 0, 0, 0.7)';
     legend.style.zIndex = '100';
-    legend.style.maxWidth = '300px';
-    legend.style.maxHeight = '50vh';
+    legend.style.width = '350px';
+    legend.style.maxHeight = '80vh';
     legend.style.overflowY = 'auto';
     legend.style.border = '1px solid rgba(100, 100, 255, 0.3)';
-    
-    // Create a header with class for windowManager to identify as drag handle
-    const header = document.createElement('div');
-    header.className = 'window-header drag-handle';
-    header.style.fontSize = '14px';
-    header.style.fontWeight = 'bold';
-    header.style.marginBottom = '8px';
-    header.style.marginTop = '-5px';
-    header.style.marginLeft = '-5px';
-    header.style.marginRight = '-5px';
-    header.style.padding = '8px';
-    header.style.display = 'flex';
-    header.style.justifyContent = 'space-between';
-    header.style.alignItems = 'center';
-    header.style.cursor = 'move';
-    header.style.borderBottom = '1px solid rgba(100, 100, 255, 0.3)';
-    
-    // Add title
-    const titleSpan = document.createElement('span');
-    titleSpan.textContent = 'Domain Colors';
-    titleSpan.className = 'window-title';
-    header.appendChild(titleSpan);
-    
-    // Add controls container
-    const controlsContainer = document.createElement('div');
-    controlsContainer.className = 'window-controls';
-    controlsContainer.style.display = 'flex';
-    controlsContainer.style.gap = '8px';
-    
-    // Add close button
-    const closeButton = document.createElement('span');
-    closeButton.textContent = '✖';
-    closeButton.className = 'window-control close-button';
-    closeButton.style.cursor = 'pointer';
-    closeButton.addEventListener('click', () => {
-      legend.style.display = 'none';
-    });
-    
-    controlsContainer.appendChild(closeButton);
-    header.appendChild(controlsContainer);
-    legend.appendChild(header);
     
     // Add to the document
     document.body.appendChild(legend);
@@ -224,12 +496,95 @@ export function updateDomainColorLegend() {
   }
   
   // Clear existing legend items
-  while (legend.childNodes.length > 1) {
-    legend.removeChild(legend.lastChild);
-  }
+  legend.innerHTML = '';
   
-  // Add legend items
-  (allDomains || []).forEach(domain => {
+  // Add title and controls
+  const header = document.createElement('h3');
+  header.className = 'window-header drag-handle';
+  header.style.margin = '0 0 15px 0';
+  header.style.padding = '0 0 10px 0';
+  header.style.borderBottom = '1px solid rgba(100, 100, 255, 0.3)';
+  header.style.display = 'flex';
+  header.style.justifyContent = 'space-between';
+  header.style.alignItems = 'center';
+  
+  const titleSpan = document.createElement('span');
+  titleSpan.textContent = 'Domain Colors';
+  titleSpan.className = 'window-title';
+  header.appendChild(titleSpan);
+  
+  // Add controls container
+  const controlsContainer = document.createElement('div');
+  controlsContainer.className = 'window-controls';
+  controlsContainer.style.display = 'flex';
+  controlsContainer.style.gap = '8px';
+  
+  // Add clipboard icon
+  const copyButton = document.createElement('span');
+  copyButton.textContent = '📋';
+  copyButton.className = 'window-control';
+  copyButton.title = 'Copy domain list';
+  copyButton.style.cursor = 'pointer';
+  copyButton.addEventListener('click', () => {
+    const text = allDomains.map(domain => {
+      const count = domainCounts.get(domain) || 0;
+      return `${domain}: ${count} node${count !== 1 ? 's' : ''}`;
+    }).join('\n');
+    
+    navigator.clipboard.writeText(text)
+      .then(() => {
+        console.log('Domain list copied to clipboard');
+        // Show feedback
+        const originalText = copyButton.textContent;
+        copyButton.textContent = '✓';
+        setTimeout(() => {
+          copyButton.textContent = originalText;
+        }, 1000);
+      })
+      .catch(err => {
+        console.error('Failed to copy domain list:', err);
+      });
+  });
+  controlsContainer.appendChild(copyButton);
+  
+  // Add create new domain button
+  const addButton = document.createElement('span');
+  addButton.textContent = '➕';
+  addButton.className = 'window-control';
+  addButton.title = 'Create new domain';
+  addButton.style.cursor = 'pointer';
+  addButton.addEventListener('click', handleCreateDomain);
+  controlsContainer.appendChild(addButton);
+  
+  // Add close button
+  const closeButton = document.createElement('span');
+  closeButton.textContent = '✖';
+  closeButton.className = 'window-control close-button';
+  closeButton.title = 'Close';
+  closeButton.style.cursor = 'pointer';
+  closeButton.addEventListener('click', () => {
+    legend.style.display = 'none';
+    // Update toggle button
+    const toggleButton = document.getElementById('toggle-domain-legend');
+    if (toggleButton) {
+      toggleButton.textContent = 'Domain Legend: OFF';
+      toggleButton.style.backgroundColor = '#525252';
+    }
+  });
+  controlsContainer.appendChild(closeButton);
+  
+  header.appendChild(controlsContainer);
+  legend.appendChild(header);
+  
+  // Add domains list container
+  const domainsContainer = document.createElement('div');
+  domainsContainer.style.display = 'flex';
+  domainsContainer.style.flexDirection = 'column';
+  domainsContainer.style.gap = '8px';
+  legend.appendChild(domainsContainer);
+  
+  // Add each domain
+  allDomains.forEach(domain => {
     // Get color for this domain
     let color = '#aaaaff'; // Default color
     
@@ -237,29 +592,142 @@ export function updateDomainColorLegend() {
       color = window.domainColors.get(domain);
     }
     
-    // Create legend item
+    // Get node count
+    const nodeCount = domainCounts.get(domain) || 0;
+    
+    // Create domain item
     const item = document.createElement('div');
+    item.className = 'domain-item';
     item.style.display = 'flex';
     item.style.alignItems = 'center';
-    item.style.marginBottom = '5px';
+    item.style.padding = '8px 10px';
+    item.style.backgroundColor = 'rgba(40, 40, 60, 0.7)';
+    item.style.borderRadius = '6px';
+    item.style.transition = 'all 0.2s ease';
+    
+    // Hover effect
+    item.addEventListener('mouseenter', () => {
+      item.style.backgroundColor = 'rgba(50, 50, 70, 0.9)';
+      item.style.transform = 'translateY(-2px)';
+    });
+    
+    item.addEventListener('mouseleave', () => {
+      item.style.backgroundColor = 'rgba(40, 40, 60, 0.7)';
+      item.style.transform = 'translateY(0)';
+    });
     
     // Color swatch
     const swatch = document.createElement('div');
     swatch.style.width = '16px';
     swatch.style.height = '16px';
     swatch.style.backgroundColor = color;
-    swatch.style.marginRight = '8px';
+    swatch.style.marginRight = '10px';
     swatch.style.borderRadius = '3px';
+    swatch.style.boxShadow = '0 1px 3px rgba(0, 0, 0, 0.3)';
     item.appendChild(swatch);
+    
+    // Domain name and count container
+    const textContainer = document.createElement('div');
+    textContainer.style.flex = '1';
+    textContainer.style.display = 'flex';
+    textContainer.style.justifyContent = 'space-between';
+    textContainer.style.alignItems = 'center';
     
     // Domain name
     const name = document.createElement('div');
     name.textContent = domain;
-    name.style.fontSize = '13px';
-    item.appendChild(name);
+    name.style.fontSize = '14px';
+    textContainer.appendChild(name);
     
-    legend.appendChild(item);
+    // Node count
+    const count = document.createElement('div');
+    count.textContent = nodeCount;
+    count.style.fontSize = '12px';
+    count.style.backgroundColor = 'rgba(100, 100, 255, 0.2)';
+    count.style.borderRadius = '12px';
+    count.style.padding = '2px 8px';
+    count.style.marginLeft = '10px';
+    textContainer.appendChild(count);
+    
+    item.appendChild(textContainer);
+    
+    // Controls container
+    const itemControls = document.createElement('div');
+    itemControls.style.display = 'flex';
+    itemControls.style.gap = '8px';
+    itemControls.style.marginLeft = '10px';
+    
+    // Edit button
+    const editButton = document.createElement('span');
+    editButton.textContent = '✏️';
+    editButton.title = 'Rename domain';
+    editButton.style.cursor = 'pointer';
+    editButton.style.fontSize = '14px';
+    editButton.style.opacity = '0.7';
+    editButton.style.transition = 'opacity 0.2s';
+    
+    editButton.addEventListener('mouseenter', () => {
+      editButton.style.opacity = '1';
+    });
+    
+    editButton.addEventListener('mouseleave', () => {
+      editButton.style.opacity = '0.7';
+    });
+    
+    editButton.addEventListener('click', () => {
+      handleRenameDomain(domain);
+    });
+    
+    itemControls.appendChild(editButton);
+    
+    // Delete button (only if domain has no nodes)
+    if (nodeCount === 0) {
+      const deleteButton = document.createElement('span');
+      deleteButton.textContent = '🗑️';
+      deleteButton.title = 'Delete empty domain';
+      deleteButton.style.cursor = 'pointer';
+      deleteButton.style.fontSize = '14px';
+      deleteButton.style.opacity = '0.7';
+      deleteButton.style.transition = 'opacity 0.2s';
+      deleteButton.className = 'delete-button';
+      
+      deleteButton.addEventListener('mouseenter', () => {
+        deleteButton.style.opacity = '1';
+      });
+      
+      deleteButton.addEventListener('mouseleave', () => {
+        deleteButton.style.opacity = '0.7';
+      });
+      
+      deleteButton.addEventListener('click', () => {
+        handleDeleteEmptyDomain(domain);
+      });
+      
+      itemControls.appendChild(deleteButton);
+    }
+    
+    item.appendChild(itemControls);
+    domainsContainer.appendChild(item);
   });
+  
+  // Add "Create new domain" button at the bottom
+  const createButtonContainer = document.createElement('div');
+  createButtonContainer.style.marginTop = '15px';
+  createButtonContainer.style.display = 'flex';
+  createButtonContainer.style.justifyContent = 'center';
+  
+  const createButton = document.createElement('button');
+  createButton.textContent = 'Create New Domain';
+  createButton.style.padding = '8px 16px';
+  createButton.style.backgroundColor = '#2a5298';
+  createButton.style.color = '#fff';
+  createButton.style.border = 'none';
+  createButton.style.borderRadius = '4px';
+  createButton.style.cursor = 'pointer';
+  createButton.addEventListener('click', handleCreateDomain);
+  
+  createButtonContainer.appendChild(createButton);
+  legend.appendChild(createButtonContainer);
   
   // Create toggle button if it doesn't exist
   if (!document.getElementById('toggle-domain-legend')) {
@@ -364,5 +832,9 @@ export default {
   getCurrentPageDomains,
   nextDomainPage,
   prevDomainPage,
-  getDomainPaginationInfo
+  getDomainPaginationInfo,
+  getDomainNodeCounts,
+  handleCreateDomain,
+  handleRenameDomain,
+  handleDeleteEmptyDomain
 };

--- a/public/js/modules-v2/core/graph.js
+++ b/public/js/modules-v2/core/graph.js
@@ -242,6 +242,15 @@ export function initGraph() {
     .onNodeClick((node, event) => {
       const { multiSelectActive } = store.getState();
       
+      // Ensure node object is valid
+      if (!node) {
+        console.log('No valid node object provided to onNodeClick');
+        return;
+      }
+      
+      // Log the node for debugging
+      console.log('Node clicked:', node.id);
+      
       // Check if shift key is pressed or multi-select mode is active
       if (event.shiftKey || multiSelectActive) {
         handleMultiSelectNode(node);
@@ -288,7 +297,7 @@ export function initGraph() {
         return;
       }
       
-      // Default node click behavior - show node details
+      // Default node click behavior - show node details or deselect if already selected
       handleViewNodeDetails(node);
     })
     

--- a/public/js/modules-v2/core/graph.js
+++ b/public/js/modules-v2/core/graph.js
@@ -9,7 +9,7 @@ import { getNodeLabel, getNodeColor, getLinkColor, updateHighlight, updateCombin
 import { showContextMenu, hideContextMenu } from '../ui/contextMenu.js';
 import { handleViewNodeDetails, handleMultiSelectNode, handleDeleteNode, showCustomConfirmDialog } from './nodeInteractions.js';
 import { toggleLinkCreationMode, handleCreateLink, handleDeleteLink } from './linkManagement.js';
-import { collectAllDomains, updateDomainColorLegend } from './domainManagement.js';
+import { collectAllDomains, updateMemoryDomainsPanel } from './domainManagement.js';
 import * as eventBus from '../utils/eventBus.js';
 
 /**

--- a/public/js/modules-v2/core/nodeInteractions.js
+++ b/public/js/modules-v2/core/nodeInteractions.js
@@ -1002,11 +1002,11 @@ export function applyDomainChangeToSelectedNodes(newDomain) {
         // Update state
         store.set('graphData', graphData);
         
-        // Update domain color legend if the domain is new
+        // Update memory domains panel if the domain is new
         const allDomains = store.get('allDomains') || [];
         if (!allDomains.includes(newDomain)) {
           domainModule.collectAllDomains();
-          domainModule.updateDomainColorLegend();
+          domainModule.updateMemoryDomainsPanel();
         }
         
         // Show result

--- a/public/js/modules-v2/core/nodeInteractions.js
+++ b/public/js/modules-v2/core/nodeInteractions.js
@@ -697,6 +697,14 @@ eventBus.on('node:editTags', () => {
   }
 });
 
+eventBus.on('node:delete', (data) => {
+  // If node is not provided, use the currently selected node
+  const node = data.node || store.get('selectedNode');
+  if (node) {
+    handleDeleteNode(node);
+  }
+});
+
 eventBus.on('node:selectionCleared', () => {
   // Clear selected node
   store.set('selectedNode', null);

--- a/public/js/modules-v2/core/nodeInteractions.js
+++ b/public/js/modules-v2/core/nodeInteractions.js
@@ -557,14 +557,6 @@ export function hideSelectionPanel() {
  * Set up selection panel event listeners
  */
 export function setupSelectionPanelListeners() {
-  // Selection panel close button
-  const closeButton = document.getElementById('selection-close');
-  if (closeButton) {
-    closeButton.addEventListener('click', () => {
-      hideSelectionPanel();
-    });
-  }
-  
   // Clear selection button
   const clearButton = document.getElementById('clear-selection-btn');
   if (clearButton) {
@@ -599,23 +591,11 @@ export function setupSelectionPanelListeners() {
     });
   }
   
-  // Selection panel copy button
-  const copyButton = document.getElementById('selection-copy');
-  if (copyButton) {
-    copyButton.addEventListener('click', () => {
-      const { multiSelectedNodes } = store.getState();
-      
-      // Create text to copy
-      const text = multiSelectedNodes.map(node => node.id).join('\n');
-      
-      // Copy to clipboard
-      navigator.clipboard.writeText(text)
-        .then(() => {
-          console.log('Selection copied to clipboard');
-        })
-        .catch(err => {
-          console.error('Failed to copy selection:', err);
-        });
+  // Change domain button
+  const domainButton = document.getElementById('change-domain-btn');
+  if (domainButton) {
+    domainButton.addEventListener('click', () => {
+      handleChangeSelectedNodesDomain();
     });
   }
 }
@@ -689,6 +669,342 @@ export function handleLinkAllSelected() {
     });
 }
 
+/**
+ * Handle deleting multiple selected nodes
+ */
+export function handleDeleteSelectedNodes() {
+  const { multiSelectedNodes } = store.getState();
+  
+  if (!multiSelectedNodes || multiSelectedNodes.length === 0) {
+    console.log('No nodes selected for deletion');
+    return;
+  }
+  
+  // Show confirmation dialog
+  showCustomConfirmDialog(
+    `Are you sure you want to delete ${multiSelectedNodes.length} selected nodes?`,
+    () => {
+      // Create a copy of the array to avoid issues during deletion
+      const nodesToDelete = [...multiSelectedNodes];
+      let deletedCount = 0;
+      let errorCount = 0;
+      
+      // Sequential deletion with Promise.all and fetch
+      const deletePromises = nodesToDelete.map(node => {
+        return fetch(`/api/nodes/${node.id}`, {
+          method: 'DELETE'
+        })
+        .then(response => response.json())
+        .then(result => {
+          if (result.success) {
+            console.log(`Node ${node.id} deleted successfully`);
+            deletedCount++;
+            return { success: true, node };
+          } else {
+            console.error(`Failed to delete node ${node.id}:`, result.error);
+            errorCount++;
+            return { success: false, node, error: result.error };
+          }
+        })
+        .catch(error => {
+          console.error(`Error deleting node ${node.id}:`, error);
+          errorCount++;
+          return { success: false, node, error };
+        });
+      });
+      
+      // Process all deletions
+      Promise.all(deletePromises)
+        .then(results => {
+          console.log(`Deleted ${deletedCount}/${nodesToDelete.length} nodes, ${errorCount} errors`);
+          
+          // Remove deleted nodes from graph data
+          const { graphData } = store.getState();
+          
+          // Get successfully deleted node IDs
+          const deletedNodeIds = results
+            .filter(result => result.success)
+            .map(result => result.node.id);
+          
+          // Remove nodes
+          graphData.nodes = graphData.nodes.filter(node => !deletedNodeIds.includes(node.id));
+          
+          // Remove connected links
+          graphData.links = graphData.links.filter(link => {
+            const sourceId = typeof link.source === 'object' ? link.source.id : link.source;
+            const targetId = typeof link.target === 'object' ? link.target.id : link.target;
+            
+            return !deletedNodeIds.includes(sourceId) && !deletedNodeIds.includes(targetId);
+          });
+          
+          // Update the graph
+          const { graph } = store.getState();
+          if (graph) {
+            graph.graphData(graphData);
+          }
+          
+          // Update state
+          store.set('graphData', graphData);
+          
+          // Clear selection
+          store.update({
+            multiSelectActive: false,
+            multiSelectedNodes: [],
+            multiSelectHighlightNodes: new Set()
+          });
+          
+          // Update visual highlighting
+          updateCombinedHighlights();
+          updateHighlight();
+          
+          // Hide selection panel
+          hideSelectionPanel();
+          
+          // Show result
+          alert(`Deleted ${deletedCount} nodes, ${errorCount} errors`);
+        });
+    }
+  );
+}
+
+/**
+ * Show domain selection dialog for selected nodes
+ */
+export function handleChangeSelectedNodesDomain() {
+  const { multiSelectedNodes } = store.getState();
+  
+  if (!multiSelectedNodes || multiSelectedNodes.length === 0) {
+    console.log('No nodes selected for domain change');
+    return;
+  }
+  
+  // Import domain management
+  import('./domainManagement.js').then(domainModule => {
+    // Get all domains
+    const allDomains = store.get('allDomains') || domainModule.collectAllDomains();
+    
+    // Create a simple modal for domain selection
+    const modal = document.createElement('div');
+    modal.style.position = 'fixed';
+    modal.style.top = '50%';
+    modal.style.left = '50%';
+    modal.style.transform = 'translate(-50%, -50%)';
+    modal.style.backgroundColor = 'rgba(30, 30, 40, 0.95)';
+    modal.style.padding = '20px';
+    modal.style.borderRadius = '8px';
+    modal.style.boxShadow = '0 0 20px rgba(0, 0, 0, 0.7)';
+    modal.style.zIndex = '1000';
+    modal.style.minWidth = '300px';
+    modal.style.maxWidth = '500px';
+    modal.style.maxHeight = '80vh';
+    modal.style.overflowY = 'auto';
+    modal.style.border = '1px solid rgba(100, 100, 255, 0.3)';
+    
+    // Add header
+    const header = document.createElement('h3');
+    header.textContent = `Change Domain for ${multiSelectedNodes.length} Nodes`;
+    header.style.marginTop = '0';
+    header.style.marginBottom = '15px';
+    header.style.color = '#aaccff';
+    header.style.borderBottom = '1px solid #5a5a8a';
+    header.style.paddingBottom = '10px';
+    modal.appendChild(header);
+    
+    // Add description
+    const description = document.createElement('p');
+    description.textContent = 'Select a domain to apply to all selected nodes:';
+    modal.appendChild(description);
+    
+    // Create domain container
+    const domainContainer = document.createElement('div');
+    domainContainer.style.display = 'flex';
+    domainContainer.style.flexDirection = 'column';
+    domainContainer.style.gap = '8px';
+    domainContainer.style.maxHeight = '300px';
+    domainContainer.style.overflowY = 'auto';
+    domainContainer.style.padding = '5px';
+    domainContainer.style.marginBottom = '15px';
+    
+    // Add domain options
+    allDomains.forEach(domain => {
+      const option = document.createElement('div');
+      option.className = 'domain-option';
+      option.style.display = 'flex';
+      option.style.alignItems = 'center';
+      option.style.padding = '8px 12px';
+      option.style.borderRadius = '4px';
+      option.style.cursor = 'pointer';
+      option.style.transition = 'background-color 0.2s';
+      
+      // Color indicator
+      const colorIndicator = document.createElement('div');
+      colorIndicator.style.width = '16px';
+      colorIndicator.style.height = '16px';
+      colorIndicator.style.backgroundColor = window.domainColors?.get(domain) || '#aaccff';
+      colorIndicator.style.marginRight = '10px';
+      colorIndicator.style.borderRadius = '3px';
+      option.appendChild(colorIndicator);
+      
+      // Domain name
+      const domainName = document.createElement('span');
+      domainName.textContent = domain;
+      option.appendChild(domainName);
+      
+      // Hover effect
+      option.addEventListener('mouseenter', () => {
+        option.style.backgroundColor = 'rgba(100, 100, 255, 0.2)';
+      });
+      
+      option.addEventListener('mouseleave', () => {
+        option.style.backgroundColor = 'transparent';
+      });
+      
+      // Click handler
+      option.addEventListener('click', () => {
+        // Apply domain change to all selected nodes
+        applyDomainChangeToSelectedNodes(domain);
+        // Remove modal
+        document.body.removeChild(modal);
+      });
+      
+      domainContainer.appendChild(option);
+    });
+    
+    modal.appendChild(domainContainer);
+    
+    // Add button container
+    const buttonContainer = document.createElement('div');
+    buttonContainer.style.display = 'flex';
+    buttonContainer.style.justifyContent = 'center';
+    buttonContainer.style.gap = '10px';
+    buttonContainer.style.marginTop = '15px';
+    
+    // Add cancel button
+    const cancelButton = document.createElement('button');
+    cancelButton.textContent = 'Cancel';
+    cancelButton.style.backgroundColor = '#525252';
+    cancelButton.style.color = 'white';
+    cancelButton.style.border = 'none';
+    cancelButton.style.padding = '8px 16px';
+    cancelButton.style.borderRadius = '4px';
+    cancelButton.style.cursor = 'pointer';
+    cancelButton.addEventListener('click', () => {
+      document.body.removeChild(modal);
+    });
+    buttonContainer.appendChild(cancelButton);
+    
+    modal.appendChild(buttonContainer);
+    
+    // Add to document
+    document.body.appendChild(modal);
+  });
+}
+
+/**
+ * Apply domain change to all selected nodes
+ * @param {string} newDomain - The new domain to apply
+ */
+export function applyDomainChangeToSelectedNodes(newDomain) {
+  const { multiSelectedNodes } = store.getState();
+  
+  if (!multiSelectedNodes || multiSelectedNodes.length === 0) {
+    console.log('No nodes selected for domain change');
+    return;
+  }
+  
+  console.log(`Changing domain of ${multiSelectedNodes.length} nodes to ${newDomain}`);
+  
+  // Import domain management
+  import('./domainManagement.js').then(domainModule => {
+    // Create a copy of the array to avoid issues during updates
+    const nodesToUpdate = [...multiSelectedNodes];
+    let updatedCount = 0;
+    let errorCount = 0;
+    
+    // Update each node
+    const updatePromises = nodesToUpdate.map(node => {
+      // Skip if domain is already set to the new value
+      if (node.domain === newDomain) {
+        console.log(`Node ${node.id} already has domain ${newDomain}`);
+        return Promise.resolve({ success: true, node, skipped: true });
+      }
+      
+      // Prepare update data
+      const updateData = {
+        node_id: node.id,
+        domain: newDomain
+      };
+      
+      // Update via API
+      return fetch('/api/nodes/update-domain', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(updateData)
+      })
+      .then(response => response.json())
+      .then(result => {
+        if (result.success) {
+          console.log(`Domain of node ${node.id} updated successfully`);
+          updatedCount++;
+          return { success: true, node };
+        } else {
+          console.error(`Failed to update domain of node ${node.id}:`, result.error);
+          errorCount++;
+          return { success: false, node, error: result.error };
+        }
+      })
+      .catch(error => {
+        console.error(`Error updating domain of node ${node.id}:`, error);
+        errorCount++;
+        return { success: false, node, error };
+      });
+    });
+    
+    // Process all updates
+    Promise.all(updatePromises)
+      .then(results => {
+        console.log(`Updated domain of ${updatedCount}/${nodesToUpdate.length} nodes, ${errorCount} errors`);
+        
+        // Update nodes in the graph data
+        const { graphData } = store.getState();
+        
+        // Process each successful update
+        results
+          .filter(result => result.success && !result.skipped)
+          .forEach(result => {
+            const nodeIndex = graphData.nodes.findIndex(n => n.id === result.node.id);
+            
+            if (nodeIndex !== -1) {
+              // Update the node
+              graphData.nodes[nodeIndex].domain = newDomain;
+              graphData.nodes[nodeIndex].group = newDomain; // Update group for ForceGraph rendering
+            }
+          });
+        
+        // Update the graph
+        const { graph } = store.getState();
+        if (graph) {
+          graph.graphData(graphData);
+        }
+        
+        // Update state
+        store.set('graphData', graphData);
+        
+        // Update domain color legend if the domain is new
+        const allDomains = store.get('allDomains') || [];
+        if (!allDomains.includes(newDomain)) {
+          domainModule.collectAllDomains();
+          domainModule.updateDomainColorLegend();
+        }
+        
+        // Show result
+        alert(`Updated domain of ${updatedCount} nodes, ${errorCount} errors`);
+      });
+  });
+}
+
 // Setup event listeners for cross-module communication
 eventBus.on('node:editTags', () => {
   const selectedNode = store.get('selectedNode');
@@ -703,6 +1019,14 @@ eventBus.on('node:delete', (data) => {
   if (node) {
     handleDeleteNode(node);
   }
+});
+
+eventBus.on('nodes:deleteSelected', () => {
+  handleDeleteSelectedNodes();
+});
+
+eventBus.on('nodes:changeDomain', () => {
+  handleChangeSelectedNodesDomain();
 });
 
 eventBus.on('node:selectionCleared', () => {
@@ -726,6 +1050,9 @@ export default {
   handleShowTagInput,
   addTagToNode,
   handleDeleteNode,
+  handleDeleteSelectedNodes,
+  handleChangeSelectedNodesDomain,
+  applyDomainChangeToSelectedNodes,
   showCustomConfirmDialog,
   showSelectionPanel,
   updateSelectionPanelPosition,

--- a/public/js/modules-v2/core/nodeInteractions.js
+++ b/public/js/modules-v2/core/nodeInteractions.js
@@ -16,8 +16,18 @@ import * as eventBus from '../utils/eventBus.js';
 export function handleViewNodeDetails(node) {
   const currentSelectedNode = store.get('selectedNode');
   
-  // Check if the node is already selected
-  if (currentSelectedNode && currentSelectedNode.id === node.id) {
+  // Add check to ensure we have a valid node object
+  if (!node) {
+    console.log('No node provided to handleViewNodeDetails');
+    return;
+  }
+  
+  // Check if the node is already selected by comparing IDs
+  const isSameNode = currentSelectedNode && 
+                     (currentSelectedNode.id === node.id || 
+                      currentSelectedNode === node.id);
+  
+  if (isSameNode) {
     console.log('Deselecting node:', node.id);
     
     // Clear selection

--- a/public/js/modules-v2/core/nodeInteractions.js
+++ b/public/js/modules-v2/core/nodeInteractions.js
@@ -107,6 +107,9 @@ export function handleViewNodeDetails(node) {
       
       // Show the panel
       infoPanel.style.display = 'block';
+      
+      // Always show the tag input interface (with skipViewDetails=true to avoid infinite loop)
+      handleShowTagInput(node, true);
     }
     
     // If auto-zoom is enabled, zoom to the node
@@ -181,11 +184,14 @@ export function handleMultiSelectNode(node) {
  * Show the tag input for a node
  * @param {Object} node - The node to add tags to
  */
-export function handleShowTagInput(node) {
+export function handleShowTagInput(node, skipViewDetails = false) {
   console.log('Showing tag input for node:', node.id);
   
-  // First, ensure the info panel is shown for this node
-  handleViewNodeDetails(node);
+  // If not skipping view details, ensure the info panel is shown for this node
+  if (!skipViewDetails) {
+    handleViewNodeDetails(node);
+    return; // handleViewNodeDetails will call this function again with skipViewDetails=true
+  }
   
   // Get the node tags element
   const nodeTags = document.getElementById('node-tags');
@@ -687,7 +693,7 @@ export function handleLinkAllSelected() {
 eventBus.on('node:editTags', () => {
   const selectedNode = store.get('selectedNode');
   if (selectedNode) {
-    handleShowTagInput(selectedNode);
+    handleShowTagInput(selectedNode, true);
   }
 });
 

--- a/public/js/modules-v2/ui/contextMenu.js
+++ b/public/js/modules-v2/ui/contextMenu.js
@@ -136,7 +136,7 @@ function populateNodeContextMenu(contextMenu, node) {
   // Add tag option
   const addTag = createMenuItem('Add Tag', () => {
     hideContextMenu();
-    handleShowTagInput(node);
+    handleShowTagInput(node, false);
   });
   contextMenu.appendChild(addTag);
   

--- a/public/js/modules-v2/ui/controls.js
+++ b/public/js/modules-v2/ui/controls.js
@@ -143,7 +143,7 @@ export function toggleHelpCard() {
 /**
  * Toggle domain legend visibility
  */
-export function toggleDomainLegend() {
+export function toggleMemoryDomainsPanel() {
   // Get the domain legend element
   const domainLegend = document.getElementById('domain-legend');
   
@@ -156,11 +156,11 @@ export function toggleDomainLegend() {
   // Update the button appearance
   const toggleButton = document.getElementById('toggle-domain-legend');
   if (toggleButton) {
-    toggleButton.textContent = `Domain Legend: ${!isVisible ? 'ON' : 'OFF'}`;
+    toggleButton.textContent = `Memory Domains: ${!isVisible ? 'ON' : 'OFF'}`;
     toggleButton.style.backgroundColor = !isVisible ? '#3388ff' : '#525252';
   }
   
-  console.log(`Domain legend ${!isVisible ? 'shown' : 'hidden'}`);
+  console.log(`Memory Domains panel ${!isVisible ? 'shown' : 'hidden'}`);
 }
 
 /**
@@ -210,6 +210,6 @@ export default {
   toggleEdgeLabels,
   toggleZoomOnSelect,
   toggleHelpCard,
-  toggleDomainLegend,
+  toggleMemoryDomainsPanel,
   setupUIEventListeners
 };

--- a/public/js/modules-v2/ui/windowManager.js
+++ b/public/js/modules-v2/ui/windowManager.js
@@ -355,16 +355,6 @@ export function initializeDraggableWindows() {
   // Info panel
   makeDraggable('info-panel', {
     controls: [
-      { 
-        icon: '📋', 
-        title: 'Copy to clipboard',
-        onClick: createControlHandlers.copyNodeContent()
-      },
-      {
-        icon: '✏️',
-        title: 'Edit tags',
-        onClick: createControlHandlers.editTags()
-      },
       {
         icon: '✖',
         title: 'Close',

--- a/public/js/modules-v2/ui/windowManager.js
+++ b/public/js/modules-v2/ui/windowManager.js
@@ -13,7 +13,8 @@ const EVENTS = {
   CONTENT_COPIED: 'content:copied',
   NODE_EDIT_TAGS: 'node:editTags',
   NODE_SELECTION_CLEARED: 'node:selectionCleared',
-  NODE_SELECTION_CHANGED: 'node:selectionChanged'
+  NODE_SELECTION_CHANGED: 'node:selectionChanged',
+  NODE_DELETE: 'node:delete'
 };
 
 // Register event handlers
@@ -329,6 +330,13 @@ const createControlHandlers = {
     };
   },
   
+  deleteNode: () => {
+    return () => {
+      // Emit an event to delete the node (to be handled by nodeInteractions)
+      eventBus.emit(EVENTS.NODE_DELETE, { node: null });
+    };
+  },
+  
   editTags: () => {
     return () => {
       // Emit an event to request tag editing
@@ -355,6 +363,17 @@ export function initializeDraggableWindows() {
   // Info panel
   makeDraggable('info-panel', {
     controls: [
+      { 
+        icon: '📋', 
+        title: 'Copy to clipboard',
+        onClick: createControlHandlers.copyNodeContent()
+      },
+      {
+        icon: '🗑️',
+        title: 'Delete node',
+        className: 'delete-button',
+        onClick: createControlHandlers.deleteNode()
+      },
       {
         icon: '✖',
         title: 'Close',

--- a/public/js/modules-v2/ui/windowManager.js
+++ b/public/js/modules-v2/ui/windowManager.js
@@ -24,7 +24,7 @@ function setupEventListeners() {
   // Listen for domain legend creation events
   eventBus.on('domainLegend:created', (legendId) => {
     if (document.getElementById(legendId)) {
-      makeDraggable(legendId, { addHeader: false });
+      makeDraggable(legendId, { controls: [] });
     }
   });
 }
@@ -463,7 +463,7 @@ export function initializeDraggableWindows() {
   const domainLegend = document.getElementById('domain-legend');
   if (domainLegend) {
     makeDraggable('domain-legend', {
-      // No custom controls needed, it already has a close button
+      controls: [] // No custom controls needed, they are already added in the updateDomainColorLegend function
     });
   }
   

--- a/public/js/modules-v2/utils/helpers.js
+++ b/public/js/modules-v2/utils/helpers.js
@@ -106,14 +106,14 @@ export function getNodeColor(node) {
         try {
           // Import the domainManagement module dynamically to avoid circular references
           import('../core/domainManagement.js').then(domainManagement => {
-            if (typeof domainManagement.updateDomainColorLegend === 'function') {
-              domainManagement.updateDomainColorLegend();
+            if (typeof domainManagement.updateMemoryDomainsPanel === 'function') {
+              domainManagement.updateMemoryDomainsPanel();
             }
           }).catch(error => {
-            console.warn('Failed to update domain color legend:', error);
+            console.warn('Failed to update memory domains panel:', error);
           });
         } catch (error) {
-          console.warn('Failed to update domain color legend:', error);
+          console.warn('Failed to update memory domains panel:', error);
         }
       }, 0);
     }


### PR DESCRIPTION
## Summary
- Rename 'Domain Colors' panel to 'Memory Domains' for clarity
- Add functionality to select all nodes in a domain with one click
- Update all references across the codebase
- Make domain node count badge clickable to select all nodes in that domain

## Test plan
- Verify that the panel title shows 'Memory Domains'
- Verify that all button text is updated
- Verify that clicking on the count badge for a domain selects all nodes in that domain
- Verify that hovering over the count badge shows a tooltip