### PR TITLE
Fix edge label toggle functionality

### DIFF
--- a/public/js/modules-v2/core/graph/initialization.js
+++ b/public/js/modules-v2/core/graph/initialization.js
@@ -45,36 +45,37 @@ export function initGraph() {
     .linkOpacity(1)
     .linkCurvature(0)
     
-    // Link labels
+    // Link labels are always enabled for tooltips
     .linkLabel(link => `${link.type} (${link.strength.toFixed(2)})`)
-    .linkThreeObjectExtend(true)
-    .linkThreeObject(link => {
-      const { showEdgeLabels } = store.getState();
-      
-      if (showEdgeLabels && typeof SpriteText !== 'undefined') {
-        const sprite = new SpriteText(link.type);
-        sprite.color = 'white';
-        sprite.textHeight = 4;
-        sprite.backgroundColor = 'rgba(0,0,0,0.7)';
-        sprite.padding = 3;
-        return sprite;
-      }
-      
-      return null;
-    })
+    .linkThreeObjectExtend(true);
     
-    // Position link objects (labels)
-    .linkPositionUpdate((sprite, { start, end }) => {
-      if (sprite) {
-        // Position the sprite at the middle of the link
-        const middlePos = {
-          x: start.x + (end.x - start.x) / 2,
-          y: start.y + (end.y - start.y) / 2,
-          z: start.z + (end.z - start.z) / 2
-        };
-        Object.assign(sprite.position, middlePos);
-      }
-    });
+  // Apply edge labels if enabled in store
+  const showEdgeLabels = store.get('showEdgeLabels');
+  if (showEdgeLabels) {
+    graph
+      .linkThreeObject(link => {
+        if (typeof SpriteText !== 'undefined') {
+          const sprite = new SpriteText(link.type);
+          sprite.color = 'white';
+          sprite.textHeight = 4;
+          sprite.backgroundColor = 'rgba(0,0,0,0.7)';
+          sprite.padding = 3;
+          return sprite;
+        }
+        return null;
+      })
+      .linkPositionUpdate((sprite, { start, end }) => {
+        if (sprite) {
+          // Position the sprite at the middle of the link
+          const middlePos = {
+            x: start.x + (end.x - start.x) / 2,
+            y: start.y + (end.y - start.y) / 2,
+            z: start.z + (end.z - start.z) / 2
+          };
+          Object.assign(sprite.position, middlePos);
+        }
+      });
+  }
   
   // Set up node 3D objects
   setupNodeThreeObjects(graph);
@@ -97,10 +98,10 @@ export function initGraph() {
     position: { x: 0, y: -200, z: 0 }, // Initial position, will be adjusted after data loads
     size: 2000,
     divisions: 50,
-    color1: 0x444466,
-    color2: 0x222244,
-    planeColor: 0x080820,
-    planeOpacity: 0.1,
+    color1: 0x444466, // Standard grid color
+    color2: 0x222244, // Standard secondary grid color
+    planeColor: 0x080820, // Standard plane color
+    planeOpacity: 0.1, // Standard plane opacity
     visible: true,
     autoAdjust: true // Enable automatic adjustment
   });

--- a/public/js/modules-v2/core/graph/referencePlane.js
+++ b/public/js/modules-v2/core/graph/referencePlane.js
@@ -43,7 +43,7 @@ export function addReferencePlane(graph, options = {}) {
   gridHelper.visible = config.visible;
   gridHelper.name = 'gridHelper'; // For identification
   
-  // If we want a semi-transparent plane as well
+  // Create a semi-transparent plane for better visual reference
   const planeGeometry = new THREE.PlaneGeometry(config.size, config.size);
   const planeMaterial = new THREE.MeshBasicMaterial({
     color: config.planeColor,

--- a/public/js/modules-v2/core/visualizationManager.js
+++ b/public/js/modules-v2/core/visualizationManager.js
@@ -105,13 +105,48 @@ export function applyVisualizationStyle(styleId) {
     .linkColor(style.linkColor)
     .linkCurvature(style.linkCurvature)
     .linkOpacity(style.linkOpacity)
-    .linkThreeObject(null) // No custom objects
-    .linkThreeObjectExtend(true) // Enable default line rendering
-    .linkPositionUpdate(null) // No custom position updates
     .linkResolution(6) // Higher resolution for smoother lines
     .linkDirectionalArrowLength(style.linkDirectionalArrowLength)
     .linkDirectionalArrowRelPos(style.linkDirectionalArrowRelPos)
     .linkDirectionalParticles(0); // No particles
+    
+  // Handle edge labels separately - preserve showEdgeLabels setting
+  const showEdgeLabels = store.get('showEdgeLabels');
+  if (showEdgeLabels) {
+    // Create link labels using SpriteText
+    graph.linkThreeObject(link => {
+      if (typeof SpriteText !== 'undefined') {
+        const sprite = new SpriteText(link.type);
+        sprite.color = 'white';
+        sprite.textHeight = 4;
+        sprite.backgroundColor = 'rgba(0,0,0,0.7)';
+        sprite.padding = 3;
+        return sprite;
+      }
+      return null;
+    });
+    
+    // Position link labels at the middle of links
+    graph.linkPositionUpdate((sprite, { start, end }) => {
+      if (sprite) {
+        // Position the sprite at the middle of the link
+        const middlePos = {
+          x: start.x + (end.x - start.x) / 2,
+          y: start.y + (end.y - start.y) / 2,
+          z: start.z + (end.z - start.z) / 2
+        };
+        Object.assign(sprite.position, middlePos);
+      }
+    });
+    
+    // Ensure the link line is still rendered
+    graph.linkThreeObjectExtend(true);
+  } else {
+    // No edge labels
+    graph.linkThreeObject(null);
+    graph.linkPositionUpdate(null);
+    graph.linkThreeObjectExtend(true);
+  }
   
   // Update currently active style
   activeVisualizationStyle = styleId;

--- a/public/js/modules-v2/ui/controls.js
+++ b/public/js/modules-v2/ui/controls.js
@@ -92,8 +92,44 @@ export function toggleEdgeLabels() {
   
   console.log(`Edge labels ${showEdgeLabels ? 'enabled' : 'disabled'}`);
   
-  // Force a refresh to update the link rendering
+  // Update link objects based on new setting
   if (graph) {
+    if (showEdgeLabels) {
+      // Create link labels using SpriteText
+      graph.linkThreeObject(link => {
+        if (typeof SpriteText !== 'undefined') {
+          const sprite = new SpriteText(link.type);
+          sprite.color = 'white';
+          sprite.textHeight = 4;
+          sprite.backgroundColor = 'rgba(0,0,0,0.7)';
+          sprite.padding = 3;
+          return sprite;
+        }
+        return null;
+      });
+      
+      // Position link labels at the middle of links
+      graph.linkPositionUpdate((sprite, { start, end }) => {
+        if (sprite) {
+          // Position the sprite at the middle of the link
+          const middlePos = {
+            x: start.x + (end.x - start.x) / 2,
+            y: start.y + (end.y - start.y) / 2,
+            z: start.z + (end.z - start.z) / 2
+          };
+          Object.assign(sprite.position, middlePos);
+        }
+      });
+    } else {
+      // Remove edge labels
+      graph.linkThreeObject(null);
+      graph.linkPositionUpdate(null);
+    }
+    
+    // Always ensure the link line is still rendered
+    graph.linkThreeObjectExtend(true);
+    
+    // Force a refresh to update the link rendering
     graph.refresh();
   }
 }

--- a/public/js/modules-v2/ui/windowManager.js
+++ b/public/js/modules-v2/ui/windowManager.js
@@ -548,6 +548,15 @@ export function initializeDraggableWindows() {
     });
   }
   
+  // About dialog (if it exists)
+  const aboutDialog = document.getElementById('about-dialog');
+  if (aboutDialog) {
+    makeDraggable('about-dialog', {
+      controls: [], // No custom controls needed, close button is already added
+      addHeader: false // We've already added a header with the class window-header
+    });
+  }
+  
   // Make context menu draggable but don't add header
   // Context menu needs special handling
   makeDraggable('context-menu', {


### PR DESCRIPTION
## Summary
- Fix edge label toggle to work instantly without page reload
- Dynamically update graph link objects when toggling labels  
- Preserve edge label state across visualization style changes

## Problem
Previously, toggling edge labels on/off required a page refresh to take effect. The labels would not update immediately when the toggle button was clicked.

## Solution
Implemented proper dynamic updating of graph link objects when the edge label toggle is activated. The changes:
1. Separated edge label rendering logic from initialization
2. Added conditional rendering based on the current showEdgeLabels state
3. Ensured link tooltips always work regardless of label visibility
4. Updated the toggle function to immediately apply changes to the graph

## Test plan
- [x] Click the Edge Labels toggle button
- [x] Verify labels appear/disappear immediately without refresh
- [x] Change visualization styles and verify edge label state persists
- [x] Hover over links and verify tooltips still work with labels off

Fixes the edge label toggle UX issue reported in user feedback.