### PR TITLE
Add shift-click drag selection box for multi-selecting nodes

### DIFF
--- a/public/js/modules-v2/core/graph/index.js
+++ b/public/js/modules-v2/core/graph/index.js
@@ -13,6 +13,7 @@ import * as interactions from './interactions.js';
 import * as dragHandling from './dragHandling.js';
 import * as events from './events.js';
 import * as referencePlane from './referencePlane.js';
+import * as selectionBox from './selectionBox.js';
 
 // Initialize event listeners
 events.setupEventListeners();
@@ -53,6 +54,11 @@ export const {
   cleanupReferencePlane
 } = referencePlane;
 
+export const {
+  initSelectionBox,
+  cleanupSelectionBox
+} = selectionBox;
+
 // Export default object with all functions
 export default {
   // Initialization
@@ -82,5 +88,9 @@ export default {
   toggleReferencePlane,
   updateReferencePlane,
   positionPlaneBelowNodes,
-  cleanupReferencePlane
+  cleanupReferencePlane,
+  
+  // Selection Box
+  initSelectionBox,
+  cleanupSelectionBox
 };

--- a/public/js/modules-v2/core/graph/initialization.js
+++ b/public/js/modules-v2/core/graph/initialization.js
@@ -11,6 +11,7 @@ import { setupLinkInteractions } from './interactions.js';
 import { setupDragHandling } from './dragHandling.js';
 import { addReferencePlane } from './referencePlane.js';
 import { initializeVisualizationManager, applyVisualizationStyle } from '../visualizationManager.js';
+import { initSelectionBox } from './selectionBox.js';
 
 /**
  * Initialize the 3D force graph
@@ -110,6 +111,9 @@ export function initGraph() {
   store.update({
     graph
   });
+  
+  // Initialize selection box functionality
+  initSelectionBox(graph);
   
   // Apply the saved visualization style after graph is initialized
   const activeStyle = store.get('visualizationStyle')?.id || 'simple';

--- a/public/js/modules-v2/core/graph/selectionBox.js
+++ b/public/js/modules-v2/core/graph/selectionBox.js
@@ -1,0 +1,223 @@
+/**
+ * Selection Box Module
+ * 
+ * Handles shift-click drag to create a selection box for multi-selecting nodes
+ */
+
+import store from '../../state/store.js';
+import { handleMultiSelectNode } from '../nodeInteractions.js';
+
+let selectionBox = null;
+let isDrawing = false;
+let startX = 0;
+let startY = 0;
+let graphCanvas = null;
+let graph = null;
+
+/**
+ * Initialize selection box functionality
+ * @param {Object} graphInstance - The 3D force graph instance
+ */
+export function initSelectionBox(graphInstance) {
+  graph = graphInstance;
+  
+  // Get the canvas element that the graph renders to
+  const graphContainer = document.getElementById('graph-container');
+  if (!graphContainer) {
+    console.error('Graph container not found');
+    return;
+  }
+  
+  // Get the canvas element within the container
+  graphCanvas = graphContainer.querySelector('canvas');
+  if (!graphCanvas) {
+    console.error('Graph canvas not found');
+    return;
+  }
+  
+  // Create selection box element
+  selectionBox = document.createElement('div');
+  selectionBox.id = 'selection-box';
+  selectionBox.style.position = 'absolute';
+  selectionBox.style.border = '2px dashed rgba(100, 100, 255, 0.8)';
+  selectionBox.style.backgroundColor = 'rgba(100, 100, 255, 0.1)';
+  selectionBox.style.pointerEvents = 'none';
+  selectionBox.style.display = 'none';
+  selectionBox.style.zIndex = '1000';
+  graphContainer.appendChild(selectionBox);
+  
+  // Add event listeners
+  graphCanvas.addEventListener('mousedown', handleMouseDown);
+  document.addEventListener('mousemove', handleMouseMove);
+  document.addEventListener('mouseup', handleMouseUp);
+  
+  // Also handle mouse leave to cancel selection if needed
+  graphCanvas.addEventListener('mouseleave', handleMouseLeave);
+}
+
+/**
+ * Handle mouse down event
+ * @param {MouseEvent} event
+ */
+function handleMouseDown(event) {
+  // Only start selection box on shift+left click on the background
+  if (!event.shiftKey || event.button !== 0) {
+    return;
+  }
+  
+  console.log('Selection box: Shift+click detected on canvas');
+  
+  // Check if we clicked on the background (not on a node)
+  const hoveredNode = store.get('hoverNode');
+  if (hoveredNode) {
+    console.log('Selection box: Cancelled - clicked on a node');
+    return; // Don't start selection box if we're over a node
+  }
+  
+  console.log('Selection box: Starting selection on background');
+  
+  // Prevent camera rotation while dragging
+  event.preventDefault();
+  event.stopPropagation();
+  
+  // Start drawing selection box
+  isDrawing = true;
+  const rect = graphCanvas.getBoundingClientRect();
+  startX = event.clientX - rect.left;
+  startY = event.clientY - rect.top;
+  
+  // Position and show selection box
+  selectionBox.style.left = startX + 'px';
+  selectionBox.style.top = startY + 'px';
+  selectionBox.style.width = '0px';
+  selectionBox.style.height = '0px';
+  selectionBox.style.display = 'block';
+  
+  // Disable camera controls while drawing
+  if (graph && graph.controls) {
+    graph.controls().enabled = false;
+  }
+}
+
+/**
+ * Handle mouse move event
+ * @param {MouseEvent} event
+ */
+function handleMouseMove(event) {
+  if (!isDrawing) return;
+  
+  const rect = graphCanvas.getBoundingClientRect();
+  const currentX = event.clientX - rect.left;
+  const currentY = event.clientY - rect.top;
+  
+  // Calculate dimensions
+  const width = Math.abs(currentX - startX);
+  const height = Math.abs(currentY - startY);
+  const left = Math.min(startX, currentX);
+  const top = Math.min(startY, currentY);
+  
+  // Update selection box
+  selectionBox.style.left = left + 'px';
+  selectionBox.style.top = top + 'px';
+  selectionBox.style.width = width + 'px';
+  selectionBox.style.height = height + 'px';
+}
+
+/**
+ * Handle mouse up event
+ * @param {MouseEvent} event
+ */
+function handleMouseUp(event) {
+  if (!isDrawing) return;
+  
+  isDrawing = false;
+  
+  // Get final selection box bounds
+  const boxRect = selectionBox.getBoundingClientRect();
+  const canvasRect = graphCanvas.getBoundingClientRect();
+  
+  // Convert to relative coordinates
+  const relativeBox = {
+    left: boxRect.left - canvasRect.left,
+    top: boxRect.top - canvasRect.top,
+    right: boxRect.right - canvasRect.left,
+    bottom: boxRect.bottom - canvasRect.top
+  };
+  
+  // Find nodes within the selection box
+  const graphData = store.get('graphData');
+  if (graphData && graphData.nodes) {
+    const selectedNodes = [];
+    
+    graphData.nodes.forEach(node => {
+      // Project node position to screen coordinates
+      const screenCoords = graph.graph2ScreenCoords(node.x, node.y, node.z);
+      
+      // Check if node is within selection box
+      if (screenCoords.x >= relativeBox.left && 
+          screenCoords.x <= relativeBox.right &&
+          screenCoords.y >= relativeBox.top && 
+          screenCoords.y <= relativeBox.bottom) {
+        selectedNodes.push(node);
+      }
+    });
+    
+    // Add selected nodes to the multi-selection
+    selectedNodes.forEach(node => {
+      handleMultiSelectNode(node);
+    });
+    
+    console.log(`Selected ${selectedNodes.length} nodes with selection box`);
+  }
+  
+  // Hide selection box
+  selectionBox.style.display = 'none';
+  
+  // Re-enable camera controls
+  if (graph && graph.controls) {
+    graph.controls().enabled = true;
+  }
+}
+
+/**
+ * Handle mouse leave event (cancel selection if mouse leaves canvas)
+ * @param {MouseEvent} event
+ */
+function handleMouseLeave(event) {
+  if (!isDrawing) return;
+  
+  // Cancel selection
+  isDrawing = false;
+  selectionBox.style.display = 'none';
+  
+  // Re-enable camera controls
+  if (graph && graph.controls) {
+    graph.controls().enabled = true;
+  }
+}
+
+/**
+ * Clean up selection box (useful when unloading the page)
+ */
+export function cleanupSelectionBox() {
+  if (graphCanvas) {
+    graphCanvas.removeEventListener('mousedown', handleMouseDown);
+    graphCanvas.removeEventListener('mouseleave', handleMouseLeave);
+  }
+  
+  document.removeEventListener('mousemove', handleMouseMove);
+  document.removeEventListener('mouseup', handleMouseUp);
+  
+  if (selectionBox && selectionBox.parentNode) {
+    selectionBox.parentNode.removeChild(selectionBox);
+  }
+  
+  selectionBox = null;
+  graphCanvas = null;
+  graph = null;
+}
+
+export default {
+  initSelectionBox,
+  cleanupSelectionBox
+};

--- a/test-selection-box.html
+++ b/test-selection-box.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Selection Box</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 20px;
+            font-family: Arial, sans-serif;
+        }
+        #graph-container {
+            width: 800px;
+            height: 600px;
+            border: 2px solid #333;
+            position: relative;
+            background: #000020;
+        }
+        .instructions {
+            margin-bottom: 20px;
+            padding: 15px;
+            background: #f0f0f0;
+            border-radius: 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="instructions">
+        <h2>Selection Box Test</h2>
+        <p>Instructions:</p>
+        <ul>
+            <li>Hold <strong>Shift</strong> and drag on the background to create a selection box</li>
+            <li>Release the mouse to select all nodes within the box</li>
+            <li>Control+click still rotates the camera</li>
+            <li>Shift+click on a node still adds it to selection</li>
+        </ul>
+    </div>
+    <div id="graph-container"></div>
+    
+    <p>Current Selection: <span id="selection-count">0</span> nodes</p>
+    
+    <script>
+        // Simple mock to test the selection box behavior
+        document.addEventListener('DOMContentLoaded', () => {
+            const container = document.getElementById('graph-container');
+            const canvas = document.createElement('canvas');
+            canvas.width = 800;
+            canvas.height = 600;
+            container.appendChild(canvas);
+            
+            console.log('Test page loaded. The actual implementation requires the full graph system.');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement shift-click drag to create a selection box for selecting multiple nodes
- Preserve existing camera controls (control+drag still rotates)
- Disable camera movement while drawing selection box

## Problem
Currently, users can only select multiple nodes by shift-clicking them one at a time, which is time-consuming for large selections.

## Solution
Implemented a selection box feature that:
1. Activates when user holds shift and drags on the background (not on nodes)
2. Draws a visual selection box with dashed border
3. Projects node 3D positions to screen coordinates
4. Selects all nodes within the box when mouse is released
5. Temporarily disables camera controls while drawing
6. Cancels selection if mouse leaves canvas

## Implementation Details
- Created new `selectionBox.js` module in graph components
- Integrated with existing multi-select functionality
- Added visual feedback with semi-transparent blue selection box
- Properly handles edge cases (clicking on nodes, leaving canvas)

## Test plan
- [x] Hold shift and drag on background to create selection box
- [x] Release mouse to select nodes within box  
- [x] Verify camera doesn't move while drawing box
- [x] Verify control+drag still rotates camera
- [x] Verify shift+click on nodes still works for multi-select
- [x] Verify selection cancels if mouse leaves canvas
- [x] Verify selection doesn't start if clicking on a node

Improves workflow efficiency for selecting multiple nodes in large graphs.